### PR TITLE
2024-07-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This is a simple [Unraid](https://unraid.net/) plugin that will let you fine-tun
 This repo merge all [pull requests](https://github.com/hugenbd/ca.mover.tuning/pulls) after review from [Hugenbd's repo](https://github.com/hugenbd/ca.mover.tuning) (cosmetics, merge skipfiletypes from shares, 4 changes from Swarles below) and add several feature, as for example automatic age threshold and compatibility with Unraid 7.x, and other stuff coming.
 
 ## Changelog
+- 2024-07-10
+    - [Unraid 7.0.0 compatibility](https://github.com/R3yn4ld/ca.mover.tuning/tree/unraid-7.0.0-compatibility) ([R3yn4ld](https://github.com/R3yn4ld)): Correct "move now without mover tuning plugin" bug (R3yn4ld)
+
 - 2024-07-07:
     - [Unraid 7.0.0 compatibility](https://github.com/R3yn4ld/ca.mover.tuning/tree/unraid-7.0.0-compatibility) ([R3yn4ld](https://github.com/R3yn4ld))
 

--- a/plugins/ca.mover.tuning.plg
+++ b/plugins/ca.mover.tuning.plg
@@ -2,18 +2,21 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name      "ca.mover.tuning">
 <!ENTITY author    "Reynald">
-<!ENTITY version   "2024.07.07">
+<!ENTITY version   "2024.07.10">
 <!ENTITY md5       "a146522a08bc8b7c4ca25fc8c0735613">
 <!ENTITY launch    "Settings/Scheduler">
 <!ENTITY plugdir   "/usr/local/emhttp/plugins/&name;">
 <!ENTITY github    "R3yn4ld/ca.mover.tuning">
-<!ENTITY branch    "automatic-age-threshold">
+<!ENTITY branch    "master">
 <!ENTITY pluginURL "https://raw.githubusercontent.com/&github;/master/plugins/&name;.plg">
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" icon="music" min="6.9.0-rc2">
 
 <CHANGES>
+###2024-07-10
+- Unraid 7.0.0 Move now without mover tuning plugin" compatibility (R3yn4ld)
+
 ###2024-07-07
 - Unraid 7.0.0 compatibility (R3yn4ld)
 
@@ -144,6 +147,7 @@ elif [[ -e /usr/libexec/unraid/move ]]; then
   echo "Creating Soft link for 7.0 or newer since /usr/local/sbin/move is now located in /usr/libexec/unraid/move"
   if [[ -e /usr/local/sbin/move ]]; then rm /usr/local/sbin/move; fi
   ln -s /usr/libexec/unraid/move /usr/local/sbin/move
+  #sed 's|ionice $ioLevel nice -n $niceLevel /usr/local/sbin/mover.old $options|ionice $ioLevel nice -n $niceLevel /usr/local/sbin/mover.old start $options\g'
 fi
 
 echo "Fixing permissions"

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -15,7 +15,7 @@ function logger($string)
     }
 }
 
-function startMover($options = "")
+function startMover($options = "start")
 {
     global $vars, $cfg, $cron;
 


### PR DESCRIPTION
Unraid 7.0.0 compatibility (/ 6.x bug?): original mover now works with "Move Now button follows plug-in filters" set to off (R3yn4ld)