### PR TITLE
Allow operation without array if multiple pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ For each file, if the file is not "in use" by any process (as detected by 'fuser
 If an error occurs in copying a file, the partial file, if present, is deleted and the operation continues on to the next file.
 
 ## Changelog
-- 2024.08.06.0813
-    - [Bug fixes](https://github.com/R3yn4ld/ca.mover.tuning/tree/2024-08-06-release5) ([R3yn4ld](https://github.com/R3yn4ld)): 
+- Next version
+    - [Allow operation without array if multiple pools]https://github.com/R3yn4ld/ca.mover.tuning/tree/Allow-operation-without-array-if-multiple-pools) ([R3yn4ld](https://github.com/R3yn4ld)) Unraid 7.0.0.beta2 may be required for this to work (6.x gui might not allow to have pool as Primary and Secondary)
+
+- 2024.08.06
+    - [Bug fixes](https://github.com/R3yn4ld/ca.mover.tuning/tree/2024-08-06-release5) ([R3yn4ld](https://github.com/R3yn4ld)) 
         - Resynchronize not working for share below moving threshold.
         - Internal mover moving files from Secondary to Primary instead of syncing (you may Resynchronize to correct the effect)
-    - 2024.08.06.0255
     - [Added Resynchronize all Primary files to Secondary option](https://github.com/R3yn4ld/ca.mover.tuning/tree/Resync-shares) ([R3yn4ld](https://github.com/R3yn4ld)): Resynchronize all Primary files to Secondary. This will resynchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected. All files will be synchronized again independently of modification time. This can be a long operation. Run-once setting will reset back to No after next run
     - Minor bug fixes and improvements ([R3yn4ld](https://github.com/R3yn4ld))
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1025,8 +1025,8 @@ start() {
 
     # Only start if config OK
     if [ -f $UNRAIDCFGFILE ]; then
-        if ! grep -qs 'shareCacheEnabled="yes"' $UNRAIDCFGFILE; then
-            mvlogger "Fatal error: cache not enabled"
+        if ! grep -qs 'shareCacheEnabled="yes"' $UNRAIDCFGFILE || [ $( ls /boot/config/pools/*.cfg | wc -l) -lt 2 ]; then
+            mvlogger "Fatal error: cache not enabled and less than 2 pools set up."
             exit 2
         fi
         if grep -qs 'shareMoverLogging="yes"' $UNRAIDCFGFILE; then


### PR DESCRIPTION
- [Allow operation without array if multiple pools](https://github.com/R3yn4ld/ca.mover.tuning/tree/Allow-operation-without-array-if-multiple-pools) ([R3yn4ld](https://github.com/R3yn4ld)) Unraid 7.0.0.beta2 may be required for this to work (6.x gui might not allow to have pool as Primary and Secondary)