### PR TITLE
Fix ctime filter bug

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -654,7 +654,11 @@ createFilteredFilelist (){
             FINDSTR+=" '"
         fi
         if [ $CTIME == "yes" ]; then
-            FINDSTR+="{filepath = \$6; cmd=\"stat -c%W \" filepath; cmd | getline result; close(cmd); sub(/\\n\$/, \"\", result); \$1 = result;"  
+            FINDSTR+="{cmd=\"stat -c%W \\\"\"\$6\"\\\"\";
+                cmd | getline result;
+                close(cmd);
+                sub(/\\n\$/, \"\", result);
+            "
         else
             FINDSTR+="{"
         fi


### PR DESCRIPTION
Fixed "move: sh: -c: line 1: syntax error near unexpected token `('" error