### PR TITLE
Assign numerical value to NBLINKS if it is unset

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1046,6 +1046,8 @@ processTheMoves () {
                 return
             fi
 
+            NBLINKS="${NBLINKS:-0}"
+
             # Skip filesize = 0 (hardlinks already handled in a previous loop)
             if [ "$NBLINKS" -gt 1 ] && [ "$FILESIZE" = 0 ] ; then
                 continue


### PR DESCRIPTION
This fixes an error where the NBLINKS is sometimes unset and results in an error been thrown:

`/usr/local/emhttp/plugins/ca.mover.tuning/age_mover: line 1050: [: : integer expression expected`